### PR TITLE
Add and Document Different Ways of Installing ROS on Different Platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use the base image from ROS
+FROM ros:noetic-ros-base-focal
+
+# Instal librealsense
+#
+# The following procedure is based on the installation guide from librealsense (from https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md)
+
+# install required tools for librealsense
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    apt-transport-https
+
+# fetch the librealsense server public key
+RUN sudo mkdir -p /etc/apt/keyrings
+RUN curl -sSf https://librealsense.intel.com/Debian/librealsense.pgp \
+    | sudo tee /etc/apt/keyrings/librealsense.pgp > /dev/null
+
+# add the librealsense server to apt-get sources
+RUN echo "deb [signed-by=/etc/apt/keyrings/librealsense.pgp] \
+    https://librealsense.intel.com/Debian/apt-repo `lsb_release -cs` main" \
+    | sudo tee /etc/apt/sources.list.d/librealsense.list
+
+# install librealsense
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # librealsense2-dkms \
+    librealsense2-utils \
+    librealsense2-dev \
+    librealsense2-dbg
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-desktop \
+    ros-noetic-rosserial \
+    ros-noetic-cv-bridge \
+    ros-noetic-rosbridge-suite \
+    ros-noetic-ddynamic-reconfigure \
+    ros-noetic-image-geometry \
+    && rm -rf /var/lib/apt/lists/*
+
+# Port 9090 is used for rosbridge
+EXPOSE 9090

--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@ To use ROS, you will need an Ubuntu system. For Windows users, options include d
 or WSL (Windows Subsystem for Linux). You can also try VPN'ing into McGill EMF (Engineering Microcomputing
 Facilities) PC's, but some of the steps will need sudo which might not be allowed.
 
+### Working on Mac
+It is also possible to install ROS with MacOS. To do so, one needs to use [RoboStack](https://robostack.github.io).
+RoboStack uses `conda`/`mamba` environments, and everything needed to get started is available directly on
+[RoboStack's documentation](https://robostack.github.io/GettingStarted.html).
+
+### Working with Docker
+An experimental alternative to work with Windows, or an alternative to RoboStack on MacOS is to use
+[Docker](https://www.docker.com/). A `Dockerfile` is available in the root of this directly, making it possible
+to directly build a ready-to-go docker image.
+
+Once docker is installed, run the following command to build the docker image:
+```bash
+docker build -t ros:mgr-rover .
+```
+
+This command builds the image and names it as `ros:mgr-rover`.
+
+Then, run the docker container in interactive mode :
+```bash
+docker run -itp 9090:9090 -v ./:/root/src ros:mgr-rover
+```
+
+- `-it` runs the container in interactive mode.
+- `-p 9090:9090` maps the port 9090 of the container to the host computer's 9090 port (for `rosbridge`).
+- `-v ./:/root/src` creates a bind mount in order to access the source code from the container.
+    __Important:__ if your `cwd` is not the root of this repository, you must change `./` (before `:`) to the
+    path leading to this repository.
+
+Now, running `catkin init` and `catkin build` inside the `root` will build the workspace.
+
 ### Installing ROS
 Follow [these steps](http://wiki.ros.org/noetic/Installation/Ubuntu) to install ROS. Next, follow [these steps](http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment) to see how to configure your shell and how to make a workspace. If you
 want, you can keep going with the tutorials to familiarize yourself with ROS and its commands. In addition, you


### PR DESCRIPTION
This makes it so that developers are not restricted to `Ubuntu` to contribute to this project. It adds documentation for MacOS users and also experimental support for a containerized environment with `docker`.